### PR TITLE
Write public method for explicitly opening a connection

### DIFF
--- a/lib/grocer/connection.rb
+++ b/lib/grocer/connection.rb
@@ -27,6 +27,10 @@ module Grocer
       end
     end
 
+    def connect
+      ssl.connect unless ssl.connected?
+    end
+
     private
 
     def ssl

--- a/spec/grocer/connection_spec.rb
+++ b/spec/grocer/connection_spec.rb
@@ -51,6 +51,11 @@ describe Grocer::Connection do
     subject.port.should == 443
   end
 
+  it 'can open the connection to the apple push notification service' do
+    subject.connect
+    ssl.should have_received(:connect)
+  end
+
   context 'an open SSLConnection' do
     before do
       ssl.stubs(:connected?).returns(true)


### PR DESCRIPTION
Before this commit sending a notification was the only way to connect
the underlying ssl connection. In the case where you would want to share
a connection across forked processes (in a resque worker for instance),
this public method comes in handy.
