### PR TITLE
Add keepalive to socket

### DIFF
--- a/lib/grocer/ssl_connection.rb
+++ b/lib/grocer/ssl_connection.rb
@@ -28,9 +28,10 @@ module Grocer
         context.cert = OpenSSL::X509::Certificate.new(cert_data)
       end
 
-      @sock     = TCPSocket.new(gateway, port)
-      @ssl      = OpenSSL::SSL::SSLSocket.new(@sock, context)
-      @ssl.sync = true
+      @sock            = TCPSocket.new(gateway, port)
+      @sock.setsockopt   Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true
+      @ssl             = OpenSSL::SSL::SSLSocket.new(@sock, context)
+      @ssl.sync        = true
       @ssl.connect
     end
 


### PR DESCRIPTION
It has been suggested by a few sources that KEEPALIVE is useful for APNS. There is no "official" documentation here, but I see no harm in it anyways. Tests are passing.

http://adam.therobots.org/talks/push.html
http://stackoverflow.com/questions/6857294/apple-feedback-service-apns-is-slow
https://devforums.apple.com/thread/114446
