### PR TITLE
Allow certificate input via any object that responds to read

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ pusher = Grocer.pusher(
 
 #### Notes
 
+* `certificate`: If you don't have the certificate stored in a file, you 
+  can pass any object that responds to `read`.
+  Example: `certificate: StringIO.new(pem_string)`
 * `gateway`: Defaults to different values depending on the `RAILS_ENV` or
   `RACK_ENV` environment variables. If set to `production`, defaults to
   `gateway.push.apple.com`, if set to `test`, defaults to `localhost` (see

--- a/lib/grocer/ssl_connection.rb
+++ b/lib/grocer/ssl_connection.rb
@@ -1,6 +1,7 @@
 require 'socket'
 require 'openssl'
 require 'forwardable'
+require 'stringio'
 
 module Grocer
   class SSLConnection
@@ -23,7 +24,14 @@ module Grocer
       context = OpenSSL::SSL::SSLContext.new
 
       if certificate
-        cert_data    = File.read(certificate)
+
+        if certificate.respond_to?(:read)
+          cert_data = certificate.read
+          certificate.rewind if certificate.respond_to?(:rewind)
+        else
+          cert_data = File.read(certificate)
+        end
+
         context.key  = OpenSSL::PKey::RSA.new(cert_data, passphrase)
         context.cert = OpenSSL::X509::Certificate.new(cert_data)
       end

--- a/spec/grocer/ssl_connection_spec.rb
+++ b/spec/grocer/ssl_connection_spec.rb
@@ -24,6 +24,21 @@ describe Grocer::SSLConnection do
     }
   }
 
+  describe 'configuration with pre-read certificate' do
+    before do
+      stub_certificate
+    end
+
+    subject {
+      string_io = File.read(connection_options[:certificate])
+      described_class.new(connection_options.merge(certificate: string_io))
+    }
+
+    it 'is initialized with a certificate 2' do
+      subject.certificate.should == File.read(connection_options[:certificate])
+    end
+  end
+  
   subject { described_class.new(connection_options) }
 
   describe 'configuration' do


### PR DESCRIPTION
With our implementation, we pass certificates via a call to a remote database. So we don't keep them as files locally, so the File.read approach doesn't work for us without trickery (such as using Tempfile#path).

This allows developers to provide an IO object that responds to #read as well. It's not perfect (a better solution would be to allow the PEM to be passed directly somehow) but it should work for most people I think!

Tests are passing. Let me know if the upstream merge screwed up the pull and I'll re-apply the code without the merge.
