### PR TITLE
Drop support for JRuby 1.6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
   - 1.9.2
   - 1.9.3
-  - jruby-19mode
   - jruby-head # To get JRuby 1.7.x, which defaults to -19mode
   - rbx-19mode
   # - ruby-head  # seems unstable on travis at this time

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in grocer.gemspec
 gemspec
-
-platforms :jruby do
-  gem 'jruby-openssl'
-end

--- a/grocer.gemspec
+++ b/grocer.gemspec
@@ -26,8 +26,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Grocer::VERSION
 
-  gem.add_dependency 'json'
-
   gem.add_development_dependency 'rspec', '~> 2.11'
   gem.add_development_dependency 'pry', '~> 0.9.8'
   gem.add_development_dependency 'mocha'


### PR DESCRIPTION
- We've long said we only support 1.7.x, and the JRuby team is pushing
  folks to get off of 1.6, so lets cut some fat drop support.
