### PR TITLE
Possible fix for #14 Socket connection drops next notification if invalid notification is sent

### DIFF
--- a/lib/grocer/connection.rb
+++ b/lib/grocer/connection.rb
@@ -36,6 +36,10 @@ module Grocer
       @ssl_connection.select timeout
     end
 
+    def pending
+      @ssl_connection.pending
+    end
+
     def close
       destroy_connection
     end

--- a/lib/grocer/notification.rb
+++ b/lib/grocer/notification.rb
@@ -4,6 +4,7 @@ require 'grocer/no_payload_error'
 module Grocer
   # Public: An object used to send notifications to APNS.
   class Notification
+    MAX_PAYLOAD_SIZE = 256
     attr_accessor :identifier, :expiry, :device_token, :alert, :badge, :sound,
                   :custom
 
@@ -39,6 +40,23 @@ module Grocer
       ].pack('CNNnH64nA*')
     end
 
+    def payload_too_large?
+      encoded_payload.bytesize > MAX_PAYLOAD_SIZE
+    end
+
+    def truncate field
+      field_val = send(field)
+      field_size = field_val.bytesize
+      payload_size = encoded_payload.bytesize
+      max_field_size = 256 - (payload_size - field_size)
+      if max_field_size > 0
+        field_val = field_val.truncate(max_field_size)
+        send(field.to_s + "=", field_val)
+      else
+        send(field.to_s + "=", nil)
+      end
+    end
+
     private
 
     def validate_payload
@@ -46,7 +64,7 @@ module Grocer
     end
 
     def encoded_payload
-      JSON.dump(payload_hash)
+      @encoded_payload ||= JSON.dump(payload_hash)
     end
 
     def payload_hash
@@ -68,6 +86,21 @@ module Grocer
 
     def device_token_length
       32
+    end
+
+    def alert= alert
+      @alert = alert
+      @encoded_payload = nil
+    end
+
+    def badge= badge
+      @badge = badge
+      @encoded_payload = nil
+    end
+
+    def sound= sound
+      @sound = sound
+      @encoded_payload = nil
     end
   end
 end

--- a/lib/grocer/pusher.rb
+++ b/lib/grocer/pusher.rb
@@ -2,14 +2,14 @@ module Grocer
   class Pusher
     def initialize(connection)
       @connection = connection
-      @errors = []
     end
 
     def push(notification)
       @connection.write(notification.to_bytes)
     end
 
-    def read_errors timeout = 0.3
+    def read_errors timeout = 0.5
+      errors = []
     	read, write, error = @connection.select(timeout)
     	if !error.nil? && !error.first.nil?
 	      Rails.logger.error "IO.select has reported an unexpected error while sending notifications."
@@ -17,10 +17,15 @@ module Grocer
 	    if !read.nil? && !read.first.nil?
 	      while error = read[0].gets
 	      	e = error.unpack("c1c1N1")
-	      	@errors << {identifier: e[2], error_code: e[1]}
+	      	errors << {identifier: e[2], error_code: e[1]}
 	      end
-	    end
-	    @errors
+      end
+      close if errors.count > 0 #force reestablish connection on next push
+	    errors
+    end
+
+    def has_errors?
+      @connection.pending > 0
     end
 
     def close

--- a/lib/grocer/ssl_connection.rb
+++ b/lib/grocer/ssl_connection.rb
@@ -6,7 +6,7 @@ require 'stringio'
 module Grocer
   class SSLConnection
     extend Forwardable
-    def_delegators :@ssl, :write, :read
+    def_delegators :@ssl, :write, :read, :pending
 
     attr_accessor :certificate, :passphrase, :gateway, :port
 


### PR DESCRIPTION
Hi, I got the same problem as described in issue #14. Later on I discovered than "invalid" device tokens which trigger the problem came from Debug versions of my app. Basically Apple drops connection and does not send anything as soon as it sees token from sandbox environment send to production one. Once I removed sandbox tokens my pushes sent fine.

But this is only part of the picture. I dig a bit deeper and implemented simple error checking as described in apple docs. You can see this code in the pull request. I used IO.select trick from "Lead Zeppeling" to get error messages. And weird thing happened. Once I read errors I see that Apple correctly reports sandbox tokens as being invalid (error code 8). But Apple reports it only once! Next pushes with same tokens (including invalid once) work without connection drops and without any errors from Apple side. I do not know who to blame this for. Maybe IO.select did the trick, maybe reading error information from socket, maybe anything else...

Anyway this pull request has the code I created to read errors. And using it I was able to fix the problem.

My sending code looks like this

``` ruby
devices.each_with_index do |device, index|
            n = Grocer::Notification.new(device_token:device.token,
                                         alert: news_content.title,
                                         identifier: index)
            pusher.push(n)
            Rails.logger.debug "Pushing #{device.token} #{news_content.title}"
end
errors = pusher.read_errors
invalid_devices = errors.map {|error| devices[error[:identifier]]}
Rails.logger.warn "APNS send resulted in errors: #{errors}"
devices.delete_all({:id.in => invalid_devices})
```
