### PR TITLE
Allow Notifications with no alert or badge, but which do have a custom payload

### DIFF
--- a/lib/grocer/notification.rb
+++ b/lib/grocer/notification.rb
@@ -47,7 +47,7 @@ module Grocer
     end
 
     def validate_payload
-      fail NoPayloadError unless alert || badge
+      fail NoPayloadError unless alert || badge || custom
       fail PayloadTooLargeError if payload_too_large?
     end
 

--- a/spec/grocer/notification_spec.rb
+++ b/spec/grocer/notification_spec.rb
@@ -49,8 +49,18 @@ describe Grocer::Notification do
     context 'missing payload' do
       let(:payload_options) { Hash.new }
 
-      it 'raises an error when neither alert nor badge is specified' do
+      it 'raises an error when none of alert, badge, or custom are specified' do
         -> { notification.to_bytes }.should raise_error(Grocer::NoPayloadError)
+      end
+
+      [{alert: 'hi'}, {badge: 1}, {custom: {a: 'b'}}].each do |payload|
+        context "when #{payload.keys.first} exists, but not any other payload keys" do
+          let(:payload_options) { payload }
+
+          it 'does not raise an error' do
+            -> { notification.to_bytes }.should_not raise_error
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Note that such notifications are discarded unless the app is foregrounded when the APN arrives.
