### PR TITLE
Add Ruby 2.1.0 to Travis config.  Fix Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 1.9.2
-  - 1.9.3
+  - 2.1.0
   - 2.0.0
-  - jruby-19mode # JRuby 1.7.0
-  - rbx-19mode
+  - 1.9.3
+  - 1.9.2
+  - jruby-19mode
+  - rbx
   # - ruby-head  # seems unstable on travis at this time

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,10 @@
 source 'https://rubygems.org'
 
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'json'
+  gem 'rubinius-developer_tools'
+end
+
 # Specify your gem's dependencies in grocer.gemspec
 gemspec


### PR DESCRIPTION
1. Added Ruby 2.1.0 to Travis config.
2. Updated Rubinius dependencies by adding explicit gems, fixing label in .travis.yml
