### PR TITLE
RSpec 3.0.x syntax changes, fix exposed broken specs

### DIFF
--- a/spec/grocer/connection_spec.rb
+++ b/spec/grocer/connection_spec.rb
@@ -35,7 +35,7 @@ describe Grocer::Connection do
 
   it 'requires a gateway' do
     connection_options.delete(:gateway)
-    -> { described_class.new(connection_options) }.should raise_error(Grocer::NoGatewayError)
+    expect { described_class.new(connection_options) }.to raise_error(Grocer::NoGatewayError)
   end
 
   it 'can be initialized with a gateway' do
@@ -44,7 +44,7 @@ describe Grocer::Connection do
 
   it 'requires a port' do
     connection_options.delete(:port)
-    -> { described_class.new(connection_options) }.should raise_error(Grocer::NoPortError)
+    expect { described_class.new(connection_options) }.to raise_error(Grocer::NoPortError)
   end
 
   it 'can be initialized with a port' do
@@ -53,12 +53,12 @@ describe Grocer::Connection do
 
   it 'can open the connection to the apple push notification service' do
     subject.connect
-    ssl.should have_received(:connect)
+    expect(ssl).to have_received(:connect)
   end
 
   it 'raises CertificateExpiredError for OpenSSL::SSL::SSLError with /certificate expired/i message' do
     ssl.stubs(:write).raises(OpenSSL::SSL::SSLError.new('certificate expired'))
-    -> {subject.write('abc123')}.should raise_error(Grocer::CertificateExpiredError)
+    expect {subject.write('abc123')}.to raise_error(Grocer::CertificateExpiredError)
   end
 
   context 'an open SSLConnection' do
@@ -68,12 +68,12 @@ describe Grocer::Connection do
 
     it '#write delegates to open SSLConnection' do
       subject.write('Apples to Oranges')
-      ssl.should have_received(:write).with('Apples to Oranges')
+      expect(ssl).to have_received(:write).with('Apples to Oranges')
     end
 
     it '#read delegates to open SSLConnection' do
       subject.read(42, 'IO')
-      ssl.should have_received(:read).with(42, 'IO')
+      expect(ssl).to have_received(:read).with(42, 'IO')
     end
   end
 
@@ -84,14 +84,14 @@ describe Grocer::Connection do
 
     it '#write connects SSLConnection and delegates to it' do
       subject.write('Apples to Oranges')
-      ssl.should have_received(:connect)
-      ssl.should have_received(:write).with('Apples to Oranges')
+      expect(ssl).to have_received(:connect)
+      expect(ssl).to have_received(:write).with('Apples to Oranges')
     end
 
     it '#read connects SSLConnection delegates to open SSLConnection' do
       subject.read(42, 'IO')
-      ssl.should have_received(:connect)
-      ssl.should have_received(:read).with(42, 'IO')
+      expect(ssl).to have_received(:connect)
+      expect(ssl).to have_received(:read).with(42, 'IO')
     end
   end
 
@@ -110,7 +110,7 @@ describe Grocer::Connection do
       it 'raises the error if none of the retries work' do
         connection_options[:retries] = 1
         ssl.stubs(:read).raises(error).then.raises(error)
-        -> { subject.read }.should raise_error(error)
+        expect { subject.read }.to raise_error(error)
       end
     end
   end

--- a/spec/grocer/error_response_spec.rb
+++ b/spec/grocer/error_response_spec.rb
@@ -4,7 +4,7 @@ describe Grocer::ErrorResponse do
   let(:status_code) { 1 }
   let(:identifier) { 8342 }
   let(:binary_tuple) { [described_class::COMMAND, status_code, identifier].pack('CCN') }
-  let(:invalid_binary_tuple) { 'totally not the right format' }
+  let(:invalid_binary_tuple) { 'short' }
 
   subject(:error_response) { described_class.new(binary_tuple) }
 
@@ -15,8 +15,7 @@ describe Grocer::ErrorResponse do
     end
 
     it 'raises an exception when there are problems decoding' do
-      -> { described_class.new(invalid_binary_tuple) }.should
-        raise_error(Grocer::InvalidFormatError)
+      expect { described_class.new(invalid_binary_tuple) }.to raise_error(Grocer::InvalidFormatError)
     end
   end
 

--- a/spec/grocer/failed_delivery_attempt_spec.rb
+++ b/spec/grocer/failed_delivery_attempt_spec.rb
@@ -5,7 +5,7 @@ describe Grocer::FailedDeliveryAttempt do
   let(:timestamp) { Time.utc(1995, 12, 21) }
   let(:device_token) { 'fe15a27d5df3c34778defb1f4f3980265cc52c0c047682223be59fb68500a9a2' }
   let(:binary_tuple) { [timestamp.to_i, 32, device_token].pack('NnH64') }
-  let(:invalid_binary_tuple) { 'totally not the right format' }
+  let(:invalid_binary_tuple) { 's' }
 
   describe 'decoding' do
     it 'accepts a binary tuple and sets each attribute' do
@@ -15,8 +15,7 @@ describe Grocer::FailedDeliveryAttempt do
     end
 
     it 'raises an exception when there are problems decoding' do
-      -> { described_class.new(invalid_binary_tuple) }.should
-        raise_error(Grocer::InvalidFormatError)
+      expect{ described_class.new(invalid_binary_tuple) }.to raise_error(Grocer::InvalidFormatError)
     end
   end
 end

--- a/spec/grocer/feedback_connection_spec.rb
+++ b/spec/grocer/feedback_connection_spec.rb
@@ -4,7 +4,7 @@ require 'grocer/feedback_connection'
 describe Grocer::FeedbackConnection do
   subject { described_class.new(options) }
   let(:options) { { certificate: '/path/to/cert.pem' } }
-  let(:connection) { stub('Connection') }
+  let(:connection) { double('Connection') }
 
   it 'delegates reading to the Connection' do
     Grocer::Connection.any_instance.expects(:read).with(42, 'lolIO')

--- a/spec/grocer/mobile_device_management_notification_spec.rb
+++ b/spec/grocer/mobile_device_management_notification_spec.rb
@@ -24,7 +24,7 @@ describe Grocer::MobileDeviceManagementNotification do
     let(:notification) { Grocer::MobileDeviceManagementNotification.new(device_token: "token", alert: "Moo") }
 
     it 'should raise a payload error' do
-      -> { notification.to_bytes }.should raise_error(Grocer::NoPayloadError)
+      expect { notification.to_bytes }.to raise_error(Grocer::NoPayloadError)
     end
   end
 
@@ -32,7 +32,7 @@ describe Grocer::MobileDeviceManagementNotification do
     let(:notification) { Grocer::MobileDeviceManagementNotification.new(device_token: "token", push_magic: "00000000-1111-3333-4444-555555555555", alert: "test") }
 
     it 'should raise a format error' do
-      -> { payload_dictionary_from_bytes }.should raise_error(Grocer::InvalidFormatError)
+      expect { payload_dictionary_from_bytes }.to raise_error(Grocer::InvalidFormatError)
     end
   end
 end

--- a/spec/grocer/notification_spec.rb
+++ b/spec/grocer/notification_spec.rb
@@ -63,7 +63,7 @@ describe Grocer::Notification do
       let(:payload_options) { Hash.new }
 
       it 'raises an error when none of alert, badge, or custom are specified' do
-        -> { notification.to_bytes }.should raise_error(Grocer::NoPayloadError)
+        expect { notification.to_bytes }.to raise_error(Grocer::NoPayloadError)
       end
 
       it 'is not valid' do
@@ -75,7 +75,7 @@ describe Grocer::Notification do
           let(:payload_options) { payload }
 
           it 'does not raise an error' do
-            -> { notification.to_bytes }.should_not raise_error
+            expect { notification.to_bytes }.not_to raise_error
           end
         end
       end
@@ -85,7 +85,7 @@ describe Grocer::Notification do
       let(:payload_options) { { alert: 'a' * (Grocer::Notification::MAX_PAYLOAD_SIZE + 1) } }
 
       it 'raises an error when the size of the payload in bytes is too large' do
-        -> { notification.to_bytes }.should raise_error(Grocer::PayloadTooLargeError)
+        expect { notification.to_bytes }.to raise_error(Grocer::PayloadTooLargeError)
       end
 
       it 'is not valid' do

--- a/spec/grocer/push_connection_spec.rb
+++ b/spec/grocer/push_connection_spec.rb
@@ -4,7 +4,7 @@ require 'grocer/push_connection'
 describe Grocer::PushConnection do
   subject { described_class.new(options) }
   let(:options) { { certificate: '/path/to/cert.pem' } }
-  let(:connection) { stub('Connection') }
+  let(:connection) { double('Connection') }
 
   it 'delegates reading to the Connection' do
     Grocer::Connection.any_instance.expects(:read).with(42, 'lolIO')

--- a/spec/grocer/pusher_spec.rb
+++ b/spec/grocer/pusher_spec.rb
@@ -11,7 +11,7 @@ describe Grocer::Pusher do
       notification = stub(:to_bytes => 'abc123')
       subject.push(notification)
 
-      connection.should have_received(:write).with('abc123')
+      expect(connection).to have_received(:write).with('abc123')
     end
   end
 end

--- a/spec/grocer/safari_notification_spec.rb
+++ b/spec/grocer/safari_notification_spec.rb
@@ -46,7 +46,7 @@ describe Grocer::SafariNotification do
         let(:payload_options) { { alert: { body: 'This is a body' } } }
 
         it 'raises an error when title is missing' do
-          -> { notification.to_bytes }.should raise_error(ArgumentError)
+          expect { notification.to_bytes }.to raise_error(ArgumentError)
         end
 
         it 'is not valid' do
@@ -58,7 +58,7 @@ describe Grocer::SafariNotification do
         let(:payload_options) { { alert: { title: 'This is a title' } } }
 
         it 'raises an error when body is missing' do
-          -> { notification.to_bytes }.should raise_error(ArgumentError)
+          expect { notification.to_bytes }.to raise_error(ArgumentError)
         end
 
         it 'is not valid' do
@@ -71,7 +71,7 @@ describe Grocer::SafariNotification do
       let(:payload_options) { { alert: { title: 'Test', body: 'a' * (Grocer::Notification::MAX_PAYLOAD_SIZE + 1) } } }
 
       it 'raises an error when the size of the payload in bytes is too large' do
-        -> { notification.to_bytes }.should raise_error(Grocer::PayloadTooLargeError)
+        expect { notification.to_bytes }.to raise_error(Grocer::PayloadTooLargeError)
       end
 
       it 'is not valid' do

--- a/spec/grocer/ssl_connection_spec.rb
+++ b/spec/grocer/ssl_connection_spec.rb
@@ -67,13 +67,13 @@ describe Grocer::SSLConnection do
 
     it 'sets up an socket connection' do
       subject.connect
-      TCPSocket.should have_received(:new).with(connection_options[:gateway],
+      expect(TCPSocket).to have_received(:new).with(connection_options[:gateway],
                                                 connection_options[:port])
     end
 
     it 'sets up an SSL connection' do
       subject.connect
-      OpenSSL::SSL::SSLSocket.should have_received(:new).with(mock_socket, anything)
+      expect(OpenSSL::SSL::SSLSocket).to have_received(:new).with(mock_socket, anything)
     end
   end
 
@@ -87,7 +87,7 @@ describe Grocer::SSLConnection do
       subject.connect
       subject.write('abc123')
 
-      mock_ssl.should have_received(:write).with('abc123')
+      expect(mock_ssl).to have_received(:write).with('abc123')
     end
   end
 
@@ -101,7 +101,7 @@ describe Grocer::SSLConnection do
       subject.connect
       subject.read(42)
 
-      mock_ssl.should have_received(:read).with(42)
+      expect(mock_ssl).to have_received(:read).with(42)
     end
   end
 end

--- a/spec/grocer_spec.rb
+++ b/spec/grocer_spec.rb
@@ -40,7 +40,7 @@ describe Grocer do
 
       it 'passes the connection options on to the underlying Connection' do
         subject.pusher(connection_options)
-        Grocer::PushConnection.should have_received(:new).with(connection_options)
+        expect(Grocer::PushConnection).to have_received(:new).with(connection_options)
       end
     end
 
@@ -55,7 +55,7 @@ describe Grocer do
 
       it 'passes the connection options on to the underlying Connection' do
         subject.feedback(connection_options)
-        Grocer::FeedbackConnection.should have_received(:new).with(connection_options)
+        expect(Grocer::FeedbackConnection).to have_received(:new).with(connection_options)
       end
     end
 
@@ -71,7 +71,7 @@ describe Grocer do
 
       it 'passes the connection options on to the underlying SSLServer' do
         subject.server(connection_options)
-        Grocer::SSLServer.should have_received(:new).with(connection_options)
+        expect(Grocer::SSLServer).to have_received(:new).with(connection_options)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ ENV['RACK_ENV'] = 'test'
 require 'mocha/api'
 require 'bourne'
 require 'support/notification_helpers'
+require 'grocer'
 
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true


### PR DESCRIPTION
1. Ran transpec to convert to RSpec 3.0.x syntax.
2. Fixed two specs which were only passing because of invalid syntax.

Running transpec exposed two specs which were only passing because of syntax errors in the original spec.  As an example, this spec:

```
-> { described_class.new(invalid_binary_tuple) }.should
       raise_error(Grocer::InvalidFormatError)
```

does not actually test whether a Grocer::InvalidFormatError is raised.  Instead the 'should' takes no argument, which ensures it always passes.  And the raise_error is called on the spec itself, and does not fail the spec.

Unfortunately String.unpack is a lot more forgiving than I think the original author thought - essentially if you pass a long enough String to String.unpack, it will decode into something.  So the only way to trigger the Grocer::InvalidFormatError is if the argument string is too short for the unpacked representation.
