### PR TITLE
Added support for SafariNotifications in the test server

### DIFF
--- a/lib/grocer/notification_reader.rb
+++ b/lib/grocer/notification_reader.rb
@@ -35,7 +35,11 @@ module Grocer
 
       payload[:custom] = payload_hash
 
-      Grocer::Notification.new(payload)
+      if payload[:url_args]
+        Grocer::SafariNotification.new( payload )
+      else
+        Grocer::Notification.new(payload)
+      end
     end
 
     def sanitize_keys(hash)

--- a/spec/grocer/server_spec.rb
+++ b/spec/grocer/server_spec.rb
@@ -29,6 +29,19 @@ describe Grocer::Server do
     }
   end
 
+  it "accepts a client connection and reads safari notifications into a queue" do
+    n = Grocer::SafariNotification.new(title: "title", body: "body")
+    expect( n ).to be_valid
+    mock_client.write(n.to_bytes)
+    mock_client.rewind
+
+    subject.accept
+    Timeout.timeout(5) {
+      notification = subject.notifications.pop
+      expect(notification.alert).to eq({:title=>"title", :body=>"body"})
+    }
+  end
+
   it "closes the socket" do
     ssl_server.expects(:close).at_least(1)
 


### PR DESCRIPTION
Currently NotificationReader will only attempt to deserialize into a regular notification, which breaks when you are trying to test SafariNotifications.  This fix will check to see if url-args is in the payload and if so create a SafariNotification object.