### PR TITLE
Notification Convenience Method: to_json

### DIFF
--- a/lib/grocer/notification.rb
+++ b/lib/grocer/notification.rb
@@ -86,6 +86,10 @@ module Grocer
       validate_payload rescue false
     end
 
+    def to_json
+      to_bytes[45..-1]
+    end
+
     private
 
     def encoded_payload

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,8 +11,8 @@ require 'support/notification_helpers'
 require 'grocer'
 
 RSpec.configure do |config|
+  # config.filter_run :focus
   config.run_all_when_everything_filtered = true
-  config.filter_run :focus
 
   config.mock_with :mocha
 

--- a/spec/support/notification_helpers.rb
+++ b/spec/support/notification_helpers.rb
@@ -4,6 +4,6 @@ module NotificationHelpers
   end
 
   def payload_bytes(notification)
-    notification.to_bytes[45..-1]
+    notification.to_json
   end
 end


### PR DESCRIPTION
Added a convenience method to provide the JSON representation of the notification.  This makes life a lot easier when you're trying to send push notifications, and see the JSON payload that is sent out.
