### PR TITLE
Add support for mutable-content flag (iOS 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ notification = Grocer::Notification.new(
   sound:             "siren.aiff",         # optional
   expiry:            Time.now + 60*60,     # optional; 0 is default, meaning the message is not stored
   identifier:        1234,                 # optional; must be an integer
-  content_available: true                  # optional; any truthy value will set 'content-available' to 1
+  content_available: true,                 # optional; any truthy value will set 'content-available' to 1
+  mutable_content:   true                  # optional; any truthy value will set 'mutable-content' to 1
 )
 
 pusher.push(notification) # return value is the number of bytes sent successfully

--- a/spec/grocer/notification_spec.rb
+++ b/spec/grocer/notification_spec.rb
@@ -60,6 +60,16 @@ describe Grocer::Notification do
       expect(payload[:aps]).to_not have_key(:'content-available')
     end
 
+    it 'encodes mutable-content as part of the payload if a truthy value is passed' do
+      notification.mutable_content = :foo
+      expect(payload[:aps][:'mutable-content']).to eq(1)
+    end
+
+    it 'does not encode mutable-content as part of the payload if a falsy value is passed' do
+      notification.mutable_content = false
+      expect(payload[:aps]).to_not have_key(:'mutable-content')
+    end
+
     it "is valid" do
       expect(notification.valid?).to be true
     end


### PR DESCRIPTION
This adds support for the new `mutable-content` flag in iOS 10:
https://developer.apple.com/videos/play/wwdc2016/707/?time=2087

We've been running this patch in production for more than a week now without any problems.